### PR TITLE
Fix hunyuan video keys

### DIFF
--- a/src/omi_model_standards/convert/lora/convert_hunyuan_video_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_hunyuan_video_lora.py
@@ -4,13 +4,13 @@ from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKey
 def __map_token_refiner_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     keys = []
 
-    keys += [LoraConversionKeySet("self_attn.qkv.0", "attn.to_q", parent=key_prefix)]
-    keys += [LoraConversionKeySet("self_attn.qkv.1", "attn.to_k", parent=key_prefix)]
-    keys += [LoraConversionKeySet("self_attn.qkv.2", "attn.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_qkv.2", "attn.to_v", parent=key_prefix)]
 
-    keys += [LoraConversionKeySet("self_attn.proj", "attn.to_out.0", parent=key_prefix)]
-    keys += [LoraConversionKeySet("mlp.0", "ff.net.0.proj", parent=key_prefix)]
-    keys += [LoraConversionKeySet("mlp.2", "ff.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("self_attn_proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("mlp.fc0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("mlp.fc2", "ff.net.2", parent=key_prefix)]
     keys += [LoraConversionKeySet("adaLN_modulation.1", "norm_out.linear", parent=key_prefix)]
     keys += [LoraConversionKeySet("norm1", "norm1", parent=key_prefix)]
     keys += [LoraConversionKeySet("norm2", "norm2", parent=key_prefix)]
@@ -21,23 +21,23 @@ def __map_token_refiner_block(key_prefix: LoraConversionKeySet) -> list[LoraConv
 def __map_double_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     keys = []
 
-    keys += [LoraConversionKeySet("img_attn.qkv.0", "attn.to_q", parent=key_prefix)]
-    keys += [LoraConversionKeySet("img_attn.qkv.1", "attn.to_k", parent=key_prefix)]
-    keys += [LoraConversionKeySet("img_attn.qkv.2", "attn.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_qkv.0", "attn.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_qkv.1", "attn.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_qkv.2", "attn.to_v", parent=key_prefix)]
 
-    keys += [LoraConversionKeySet("txt_attn.qkv.0", "attn.add_q_proj", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_attn.qkv.1", "attn.add_k_proj", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_attn.qkv.2", "attn.add_v_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_qkv.0", "attn.add_q_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_qkv.1", "attn.add_k_proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_qkv.2", "attn.add_v_proj", parent=key_prefix)]
 
-    keys += [LoraConversionKeySet("img_attn.proj", "attn.to_out.0", parent=key_prefix)]
-    keys += [LoraConversionKeySet("img_mlp.0", "ff.net.0.proj", parent=key_prefix)]
-    keys += [LoraConversionKeySet("img_mlp.2", "ff.net.2", parent=key_prefix)]
-    keys += [LoraConversionKeySet("img_mod.lin", "norm1.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_attn_proj", "attn.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.fc0", "ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mlp.fc2", "ff.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("img_mod.linear", "norm1.linear", parent=key_prefix)]
 
-    keys += [LoraConversionKeySet("txt_attn.proj", "attn.to_add_out", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_mlp.0", "ff_context.net.0.proj", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_mlp.2", "ff_context.net.2", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_mod.lin", "norm1_context.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_attn_proj", "attn.to_add_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.fc0", "ff_context.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mlp.fc2", "ff_context.net.2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_mod.linear", "norm1_context.linear", parent=key_prefix)]
 
     return keys
 
@@ -51,7 +51,7 @@ def __map_single_transformer_block(key_prefix: LoraConversionKeySet) -> list[Lor
     keys += [LoraConversionKeySet("linear1.3", "proj_mlp", parent=key_prefix)]
 
     keys += [LoraConversionKeySet("linear2", "proj_out", parent=key_prefix)]
-    keys += [LoraConversionKeySet("modulation.lin", "norm.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("modulation.linear", "norm.linear", parent=key_prefix)]
 
     return keys
 
@@ -59,19 +59,19 @@ def __map_single_transformer_block(key_prefix: LoraConversionKeySet) -> list[Lor
 def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     keys = []
 
-    keys += [LoraConversionKeySet("txt_in.c_embedder.in_layer", "context_embedder.time_text_embed.text_embedder.linear_1", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_in.c_embedder.out_layer", "context_embedder.time_text_embed.text_embedder.linear_2", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_in.t_embedder.in_layer", "context_embedder.time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
-    keys += [LoraConversionKeySet("txt_in.t_embedder.out_layer", "context_embedder.time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.c_embedder.linear_1", "context_embedder.time_text_embed.text_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.c_embedder.linear_2", "context_embedder.time_text_embed.text_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.t_embedder.linear_1", "context_embedder.time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("txt_in.t_embedder.linear_2", "context_embedder.time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
     keys += [LoraConversionKeySet("txt_in.input_embedder", "context_embedder.proj_in", parent=key_prefix)]
     keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "norm_out.linear", parent=key_prefix, swap_chunks=True)]
     keys += [LoraConversionKeySet("final_layer.linear", "proj_out", parent=key_prefix)]
-    keys += [LoraConversionKeySet("guidance_in.in_layer", "time_text_embed.guidance_embedder.linear_1", parent=key_prefix)]
-    keys += [LoraConversionKeySet("guidance_in.out_layer", "time_text_embed.guidance_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.mlp.0", "time_text_embed.guidance_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("guidance_in.mlp.2", "time_text_embed.guidance_embedder.linear_2", parent=key_prefix)]
     keys += [LoraConversionKeySet("vector_in.in_layer", "time_text_embed.text_embedder.linear_1", parent=key_prefix)]
     keys += [LoraConversionKeySet("vector_in.out_layer", "time_text_embed.text_embedder.linear_2", parent=key_prefix)]
-    keys += [LoraConversionKeySet("time_in.in_layer", "time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
-    keys += [LoraConversionKeySet("time_in.out_layer", "time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.mlp.0", "time_text_embed.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("time_in.mlp.2", "time_text_embed.timestep_embedder.linear_2", parent=key_prefix)]
     keys += [LoraConversionKeySet("img_in.proj", "x_embedder.proj", parent=key_prefix)]
 
     for k in map_prefix_range("txt_in.individual_token_refiner.blocks", "context_embedder.token_refiner.refiner_blocks", parent=key_prefix):

--- a/src/omi_model_standards/convert/lora/convert_sd_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_sd_lora.py
@@ -55,7 +55,7 @@ def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversion
     keys += __map_unet_resnet_block(LoraConversionKeySet("0.0", "0.resnets.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("2.2.conv", "0.upsamplers.0.conv", parent=key_prefix)]
+    keys += [LoraConversionKeySet("2.1.conv", "0.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))
     keys += [LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix)]

--- a/src/omi_model_standards/convert/lora/convert_sd_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_sd_lora.py
@@ -53,11 +53,8 @@ def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversion
     keys = []
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("0.0", "0.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("0.1", "0.attentions.0", parent=key_prefix)]
     keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("1.1", "0.attentions.1", parent=key_prefix)]
     keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("2.1", "0.attentions.2", parent=key_prefix)]
     keys += [LoraConversionKeySet("2.2.conv", "0.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))


### PR DESCRIPTION
This switches the Hunyuan Video key conversions to the original key names from the model authors. I originally used the names from <https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/blob/main/split_files/diffusion_models/hunyuan_video_t2v_720p_bf16.safetensors>, thinking they were the same.

Also removes mapping for non existent keys in the SD1/2 conversion