### PR TITLE
Add HiDream LoRA key conversion

### DIFF
--- a/src/omi_model_standards/convert/lora/convert_hidream_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_hidream_lora.py
@@ -1,0 +1,14 @@
+from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def convert_hidream_lora_key_sets() -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
+    keys += [LoraConversionKeySet("transformer", "lora_transformer")]
+    keys += [LoraConversionKeySet("clip_l", "lora_te1")]
+    keys += [LoraConversionKeySet("clip_g", "lora_te2")]
+    keys += [LoraConversionKeySet("t5", "lora_te3")]
+    keys += [LoraConversionKeySet("llama", "lora_te4")]
+
+    return keys


### PR DESCRIPTION
This one doesn't do much, since the original model is already in diffusers format. I just wanted to add it so we can convert between the older "lora_te1", "lora_te2", etc and the new "clip_l", "clip_g", etc prefixes