### PR TITLE
Add support for converting from the legacy_diffusers format

### DIFF
--- a/src/omi_model_standards/convert/lora/convert_clip.py
+++ b/src/omi_model_standards/convert/lora/convert_clip.py
@@ -1,0 +1,17 @@
+from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_clip(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("text_projection", "text_projection", parent=key_prefix)]
+
+    for k in map_prefix_range("text_model.encoder.layers", "text_model.encoder.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.fc1", "mlp.fc1", parent=k)]
+        keys += [LoraConversionKeySet("mlp.fc2", "mlp.fc2", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.out_proj", "self_attn.out_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys

--- a/src/omi_model_standards/convert/lora/convert_flux_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_flux_lora.py
@@ -1,4 +1,6 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from omi_model_standards.convert.lora.convert_t5 import map_t5
 
 
 def __map_double_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
@@ -62,28 +64,12 @@ def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKe
     return keys
 
 
-def __map_clip(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
-def __map_t5(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
 def convert_flux_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
-    keys += __map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
-    keys += __map_t5(LoraConversionKeySet("t5", "lora_te2"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te2"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_hidream_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_hidream_lora.py
@@ -1,14 +1,109 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
+from omi_model_standards.convert.lora.convert_llama import map_llama, map_causal_llama
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from omi_model_standards.convert.lora.convert_t5 import map_t5
+
+
+def __map_caption_projection_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("linear", "linear", parent=key_prefix)]
+
+    return keys
+
+
+def __map_double_stream_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("block.adaLN_modulation.1", "block.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k", "block.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k_t", "block.attn1.to_k_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out", "block.attn1.to_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out_t", "block.attn1.to_out_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q", "block.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q_t", "block.attn1.to_q_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v", "block.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v_t", "block.attn1.to_v_t", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w1", "block.ff_i.experts.0.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w2", "block.ff_i.experts.0.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w3", "block.ff_i.experts.0.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w1", "block.ff_i.experts.1.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w2", "block.ff_i.experts.1.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w3", "block.ff_i.experts.1.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w1", "block.ff_i.experts.2.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w2", "block.ff_i.experts.2.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w3", "block.ff_i.experts.2.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w1", "block.ff_i.experts.3.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w2", "block.ff_i.experts.3.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w3", "block.ff_i.experts.3.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w1", "block.ff_i.shared_experts.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w2", "block.ff_i.shared_experts.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w3", "block.ff_i.shared_experts.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w1", "block.ff_t.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w2", "block.ff_t.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_t.w3", "block.ff_t.w3", parent=key_prefix)]
+
+    return keys
+
+
+def __map_single_stream_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("block.adaLN_modulation.1", "block.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_k", "block.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_out", "block.attn1.to_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_q", "block.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.attn1.to_v", "block.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w1", "block.ff_i.experts.0.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w2", "block.ff_i.experts.0.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.0.w3", "block.ff_i.experts.0.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w1", "block.ff_i.experts.1.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w2", "block.ff_i.experts.1.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.1.w3", "block.ff_i.experts.1.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w1", "block.ff_i.experts.2.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w2", "block.ff_i.experts.2.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.2.w3", "block.ff_i.experts.2.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w1", "block.ff_i.experts.3.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w2", "block.ff_i.experts.3.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.experts.3.w3", "block.ff_i.experts.3.w3", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w1", "block.ff_i.shared_experts.w1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w2", "block.ff_i.shared_experts.w2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("block.ff_i.shared_experts.w3", "block.ff_i.shared_experts.w3", parent=key_prefix)]
+
+    return keys
+
+
+def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("final_layer.adaLN_modulation.1", "final_layer.adaLN_modulation.1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("final_layer.linear", "final_layer.linear", parent=key_prefix)]
+    keys += [LoraConversionKeySet("p_embedder.pooled_embedder.linear_1", "p_embedder.pooled_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("p_embedder.pooled_embedder.linear_2", "p_embedder.pooled_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.timestep_embedder.linear_1", "t_embedder.timestep_embedder.linear_1", parent=key_prefix)]
+    keys += [LoraConversionKeySet("t_embedder.timestep_embedder.linear_2", "t_embedder.timestep_embedder.linear_2", parent=key_prefix)]
+    keys += [LoraConversionKeySet("x_embedder.proj", "x_embedder.proj", parent=key_prefix)]
+
+    for k in map_prefix_range("caption_projection", "caption_projection", parent=key_prefix):
+        keys += __map_caption_projection_block(k)
+
+    for k in map_prefix_range("double_stream_blocks", "double_stream_blocks", parent=key_prefix):
+        keys += __map_double_stream_block(k)
+
+    for k in map_prefix_range("single_stream_blocks", "single_stream_blocks", parent=key_prefix):
+        keys += __map_single_stream_block(k)
+
+    return keys
 
 
 def convert_hidream_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
-    keys += [LoraConversionKeySet("transformer", "lora_transformer")]
-    keys += [LoraConversionKeySet("clip_l", "lora_te1")]
-    keys += [LoraConversionKeySet("clip_g", "lora_te2")]
-    keys += [LoraConversionKeySet("t5", "lora_te3")]
-    keys += [LoraConversionKeySet("llama", "lora_te4")]
+    keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te3"))
+    keys += map_causal_llama(LoraConversionKeySet("llama", "lora_te4"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_hunyuan_video_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_hunyuan_video_lora.py
@@ -1,3 +1,5 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
+from omi_model_standards.convert.lora.convert_llama import map_llama
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
 
 
@@ -86,28 +88,12 @@ def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKe
     return keys
 
 
-def __map_llama(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("language_model.model", "", parent=key_prefix)]
-
-    return keys
-
-
-def __map_clip(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
 def convert_hunyuan_video_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
-    keys += __map_llama(LoraConversionKeySet("llama", "lora_te1"))
-    keys += __map_clip(LoraConversionKeySet("clip_l", "lora_te2"))
+    keys += map_llama(LoraConversionKeySet("llama", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te2"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_llama.py
+++ b/src/omi_model_standards/convert/lora/convert_llama.py
@@ -1,0 +1,32 @@
+from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_llama(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    for k in map_prefix_range("language_model.model.layers", "language_model.model.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.down_proj", "mlp.down_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.gate_proj", "mlp.gate_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.up_proj", "mlp.up_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.o_proj", "self_attn.o_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys
+
+
+def map_causal_llama(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("lm_head", "lm_head", parent=key_prefix)]
+    for k in map_prefix_range("model.layers", "model.layers", parent=key_prefix):
+        keys += [LoraConversionKeySet("mlp.down_proj", "mlp.down_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.gate_proj", "mlp.gate_proj", parent=k)]
+        keys += [LoraConversionKeySet("mlp.up_proj", "mlp.up_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.k_proj", "self_attn.k_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.o_proj", "self_attn.o_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.q_proj", "self_attn.q_proj", parent=k)]
+        keys += [LoraConversionKeySet("self_attn.v_proj", "self_attn.v_proj", parent=k)]
+
+    return keys

--- a/src/omi_model_standards/convert/lora/convert_pixart_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_pixart_lora.py
@@ -1,4 +1,5 @@
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from omi_model_standards.convert.lora.convert_t5 import map_t5
 
 
 def __map_transformer_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
@@ -47,19 +48,11 @@ def __map_transformer(key_prefix: LoraConversionKeySet) -> list[LoraConversionKe
     return keys
 
 
-def __map_t5(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
 def convert_pixart_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
-    keys += __map_t5(LoraConversionKeySet("t5", "lora_te"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_sd3_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_sd3_lora.py
@@ -1,4 +1,6 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from omi_model_standards.convert.lora.convert_t5 import map_t5
 
 
 def __map_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
@@ -19,7 +21,7 @@ def __map_transformer_block(key_prefix: LoraConversionKeySet) -> list[LoraConver
     keys += [LoraConversionKeySet("x_block.adaLN_modulation.1", "norm1.linear", parent=key_prefix)]
 
     keys += [LoraConversionKeySet("context_block.adaLN_modulation.1", "norm1_context.linear", parent=key_prefix, filter_is_last=False)]
-    keys += [LoraConversionKeySet("context_block.adaLN_modulation.1", "norm1_context.linear", parent=key_prefix, swap_chunks=True, filter_is_last=False)]
+    keys += [LoraConversionKeySet("context_block.adaLN_modulation.1", "norm1_context.linear", parent=key_prefix, swap_chunks=True, filter_is_last=True)]
 
     keys += [LoraConversionKeySet("x_block.mlp.fc1", "ff.net.0.proj", parent=key_prefix)]
     keys += [LoraConversionKeySet("x_block.mlp.fc2", "ff.net.2", parent=key_prefix)]
@@ -59,8 +61,8 @@ def convert_sd3_lora_key_sets() -> list[LoraConversionKeySet]:
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_transformer(LoraConversionKeySet("transformer", "lora_transformer"))
-    keys += [LoraConversionKeySet("clip_l", "lora_te1")]
-    keys += [LoraConversionKeySet("clip_g", "lora_te2")]
-    keys += [LoraConversionKeySet("t5", "lora_te3")]
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
+    keys += map_t5(LoraConversionKeySet("t5", "lora_te3"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_sd_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_sd_lora.py
@@ -1,4 +1,5 @@
-from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+from omi_model_standards.convert.lora.convert_clip import map_clip
+from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet
 
 
 def __map_unet_resnet_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
@@ -12,25 +13,44 @@ def __map_unet_resnet_block(key_prefix: LoraConversionKeySet) -> list[LoraConver
     return keys
 
 
+def __map_unet_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("proj_in", "proj_in", parent=key_prefix)]
+    keys += [LoraConversionKeySet("proj_out", "proj_out", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_q", "transformer_blocks.0.attn1.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_k", "transformer_blocks.0.attn1.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_v", "transformer_blocks.0.attn1.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn1.to_out.0", "transformer_blocks.0.attn1.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_q", "transformer_blocks.0.attn2.to_q", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_k", "transformer_blocks.0.attn2.to_k", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_v", "transformer_blocks.0.attn2.to_v", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.attn2.to_out.0", "transformer_blocks.0.attn2.to_out.0", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.ff.net.0.proj", "transformer_blocks.0.ff.net.0.proj", parent=key_prefix)]
+    keys += [LoraConversionKeySet("transformer_blocks.0.ff.net.2", "transformer_blocks.0.ff.net.2", parent=key_prefix)]
+
+    return keys
+
+
 def __map_unet_down_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     keys = []
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("1.1", "0.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("1.1", "0.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("2.1", "0.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("2.1", "0.attentions.1", parent=key_prefix))
     keys += [LoraConversionKeySet("3.0.op", "0.downsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix))
     keys += [LoraConversionKeySet("6.0.op", "1.downsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix))
     keys += [LoraConversionKeySet("9.0.op", "2.downsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("10.0", "3.resnets.0", parent=key_prefix))
@@ -43,7 +63,7 @@ def __map_unet_mid_block(key_prefix: LoraConversionKeySet) -> list[LoraConversio
     keys = []
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("0", "resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("1", "attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("1", "attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("2", "resnets.1", parent=key_prefix))
 
     return keys
@@ -58,27 +78,27 @@ def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversion
     keys += [LoraConversionKeySet("2.1.conv", "0.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix))
     keys += [LoraConversionKeySet("5.2.conv", "1.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("6.0", "2.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("6.1", "2.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("6.1", "2.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("7.1", "2.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("8.1", "2.attentions.2", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.2", parent=key_prefix))
     keys += [LoraConversionKeySet("8.2.conv", "2.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("9.0", "3.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("9.1", "3.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("9.1", "3.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("10.0", "3.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("10.1", "3.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("10.1", "3.attentions.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("11.0", "3.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("11.1", "3.attentions.2", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("11.1", "3.attentions.2", parent=key_prefix))
 
     return keys
 
@@ -101,19 +121,11 @@ def __map_unet(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     return keys
 
 
-def __map_text_encoder(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
 def convert_sd_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_unet(LoraConversionKeySet( "unet", "lora_unet"))
-    keys += __map_text_encoder(LoraConversionKeySet("clip_l", "lora_te"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_sdxl_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_sdxl_lora.py
@@ -1,3 +1,4 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
 
 
@@ -12,6 +13,26 @@ def __map_unet_resnet_block(key_prefix: LoraConversionKeySet) -> list[LoraConver
     return keys
 
 
+def __map_unet_attention_block(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    keys += [LoraConversionKeySet("proj_in", "proj_in", parent=key_prefix)]
+    keys += [LoraConversionKeySet("proj_out", "proj_out", parent=key_prefix)]
+    for k in map_prefix_range("transformer_blocks", "transformer_blocks", parent=key_prefix):
+        keys += [LoraConversionKeySet("attn1.to_q", "attn1.to_q", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_k", "attn1.to_k", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_v", "attn1.to_v", parent=k)]
+        keys += [LoraConversionKeySet("attn1.to_out.0", "attn1.to_out.0", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_q", "attn2.to_q", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_k", "attn2.to_k", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_v", "attn2.to_v", parent=k)]
+        keys += [LoraConversionKeySet("attn2.to_out.0", "attn2.to_out.0", parent=k)]
+        keys += [LoraConversionKeySet("ff.net.0.proj", "ff.net.0.proj", parent=k)]
+        keys += [LoraConversionKeySet("ff.net.2", "ff.net.2", parent=k)]
+
+    return keys
+
+
 def __map_unet_down_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     keys = []
 
@@ -20,15 +41,15 @@ def __map_unet_down_blocks(key_prefix: LoraConversionKeySet) -> list[LoraConvers
     keys += [LoraConversionKeySet("3.0.op", "0.downsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.1", parent=key_prefix))
     keys += [LoraConversionKeySet("6.0.op", "1.downsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("7.0", "2.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("7.1", "2.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("8.0", "2.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("8.1", "2.attentions.1", parent=key_prefix))
 
     return keys
 
@@ -37,7 +58,7 @@ def __map_unet_mid_block(key_prefix: LoraConversionKeySet) -> list[LoraConversio
     keys = []
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("0", "resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("1", "attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("1", "attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("2", "resnets.1", parent=key_prefix))
 
     return keys
@@ -47,19 +68,19 @@ def __map_unet_up_block(key_prefix: LoraConversionKeySet) -> list[LoraConversion
     keys = []
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("0.0", "0.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("0.1", "0.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("0.1", "0.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("1.0", "0.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("1.1", "0.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("1.1", "0.attentions.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("2.0", "0.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("2.1", "0.attentions.2", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("2.1", "0.attentions.2", parent=key_prefix))
     keys += [LoraConversionKeySet("2.2.conv", "0.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("3.0", "1.resnets.0", parent=key_prefix))
-    keys += [LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("3.1", "1.attentions.0", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("4.0", "1.resnets.1", parent=key_prefix))
-    keys += [LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("4.1", "1.attentions.1", parent=key_prefix))
     keys += __map_unet_resnet_block(LoraConversionKeySet("5.0", "1.resnets.2", parent=key_prefix))
-    keys += [LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix)]
+    keys += __map_unet_attention_block(LoraConversionKeySet("5.1", "1.attentions.2", parent=key_prefix))
     keys += [LoraConversionKeySet("5.2.conv", "1.upsamplers.0.conv", parent=key_prefix)]
 
     keys += __map_unet_resnet_block(LoraConversionKeySet("6.0", "2.resnets.0", parent=key_prefix))
@@ -90,28 +111,12 @@ def __map_unet(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
     return keys
 
 
-def __map_text_encoder_1(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
-def __map_text_encoder_2(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
-    keys = []
-
-    keys += [LoraConversionKeySet("", "", parent=key_prefix)]
-
-    return keys
-
-
 def convert_sdxl_lora_key_sets() -> list[LoraConversionKeySet]:
     keys = []
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_unet(LoraConversionKeySet( "unet", "lora_unet"))
-    keys += __map_text_encoder_1(LoraConversionKeySet("clip_l", "lora_te1"))
-    keys += __map_text_encoder_2(LoraConversionKeySet("clip_g", "lora_te2"))
+    keys += map_clip(LoraConversionKeySet("clip_l", "lora_te1"))
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_te2"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_stable_cascade_lora.py
+++ b/src/omi_model_standards/convert/lora/convert_stable_cascade_lora.py
@@ -1,3 +1,4 @@
+from omi_model_standards.convert.lora.convert_clip import map_clip
 from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
 
 
@@ -51,6 +52,6 @@ def convert_stable_cascade_lora_key_sets() -> list[LoraConversionKeySet]:
 
     keys += [LoraConversionKeySet("bundle_emb", "bundle_emb")]
     keys += __map_prior(LoraConversionKeySet( "unet", "lora_prior_unet"))
-    keys += [LoraConversionKeySet("clip_g", "lora_prior_te")]
+    keys += map_clip(LoraConversionKeySet("clip_g", "lora_prior_te"))
 
     return keys

--- a/src/omi_model_standards/convert/lora/convert_t5.py
+++ b/src/omi_model_standards/convert/lora/convert_t5.py
@@ -1,0 +1,16 @@
+from omi_model_standards.convert.lora.convert_lora_util import LoraConversionKeySet, map_prefix_range
+
+
+def map_t5(key_prefix: LoraConversionKeySet) -> list[LoraConversionKeySet]:
+    keys = []
+
+    for k in map_prefix_range("encoder.block", "encoder.block", parent=key_prefix):
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.k", "layer.0.SelfAttention.k", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.o", "layer.0.SelfAttention.o", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.q", "layer.0.SelfAttention.q", parent=k)]
+        keys += [LoraConversionKeySet("layer.0.SelfAttention.v", "layer.0.SelfAttention.v", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wi_0", "layer.1.DenseReluDense.wi_0", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wi_1", "layer.1.DenseReluDense.wi_1", parent=k)]
+        keys += [LoraConversionKeySet("layer.1.DenseReluDense.wo", "layer.1.DenseReluDense.wo", parent=k)]
+
+    return keys


### PR DESCRIPTION
The initial conversion functions couldn't convert from the legacy_diffusers format to to any other format. This PR fully defines all the linear and conv layers of every supported model, which is necessary for this conversion.