### PR TITLE
Fix lora conversion for stable cascade

### DIFF
--- a/src/omi_model_standards/convert/lora/convert_lora_util.py
+++ b/src/omi_model_standards/convert/lora/convert_lora_util.py
@@ -82,6 +82,8 @@ class LoraConversionKeySet:
 
 
 def combine(left: str, right: str) -> str:
+    left = left.rstrip('.')
+    right = right.lstrip('.')
     if left == "" or left is None:
         return right
     elif right == "" or right is None:


### PR DESCRIPTION
The stable cascade conversion function produces double `.` or `_` characters in some cases. Stripping those inside the combine function fixes that issue. This should fix https://github.com/Nerogar/OneTrainer/issues/829